### PR TITLE
Less strict python version rule

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -38,8 +38,8 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [metadata]
 lock-version = "1.1"
-python-versions = "~3.7"
-content-hash = "4a410267e42b1689cf641cc793418855a70412c01d89a327826936f2ae9bbed4"
+python-versions = "^3.7"
+content-hash = "c676ef33618d5319f140cf4cf871e30373574587ea6b2b2db2c08541e867b2a5"
 
 [metadata.files]
 arrow = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = ["Kuba Karmiński <jlkarminski@gmail.com>"]
 
 [tool.poetry.dependencies]
-python = "~3.7"
+python = "^3.7"
 arrow = "0.12.1"
 ply = "3.10"
 six = "1.15"


### PR DESCRIPTION
Handle both Python 3.7 and 3.8.

Otherwise I get the following when trying to set up IWAN locally (using Python 3.8.5):

```
Using python3 (3.8.5)
Updating dependencies
Resolving dependencies... (20.3s)

SolverProblemError

The current project's Python requirement (>=3.7,<4.0) is not compatible with some of the required packages Python requirement:
  - tinyquery requires Python ~3.7, so it will not be satisfied for Python >=3.8,<4.0

Because iwan-pen depends on tinyquery (1.3 git rev v1.3) which requires Python ~3.7, version solving failed.
```